### PR TITLE
Add assert method for unauthorized response.

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -117,6 +117,23 @@ class TestResponse
 
         return $this;
     }
+    
+    /**
+     * Assert that the response has an unauthorized status code.
+     *
+     * @return $this
+     */
+    public function assertUnauthorized()
+    {
+        $actual = $this->getStatusCode();
+        
+        PHPUnit::assertTrue(
+            401 === $actual,
+            'Response status code ['.$actual.'] is not an unauthorized status code.'
+        );
+
+        return $this;
+    }
 
     /**
      * Assert that the response has the given status code.


### PR DESCRIPTION
This PR adds a new assertion method on test response like `assertNotFound` and `assertForbidden`; this will help asserting that an endpoint is limited only to authorized users instead of doing it as `assertStatus(401)`.

There is no `isUnauthorized` method defined in Symfony/http-foundation [Response](https://github.com/symfony/http-foundation/blob/master/Response.php) class like `isForbidden`, `isNotFound` _yet_ so that's why I compare it with the `401` HTTP code directly.
